### PR TITLE
use detect-node module due to unreliability of global window variable in some cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 Requires the right version of Parse JS SDK for a particular platform.
 
 
-### Raison d'État
-Versions of the Parse JS SDK >=1.6.0 split the codebase into two requireables:
+### Why?
+Versions of the Parse JS SDK >=1.9.0 split the codebase into three requireables:
 
+ - The global scope parse in cloud code
  - The version of parse for the browser `require('parse')`
  - The version of parse for node `require('parse/node')`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-shim",
-  "version": "1.0.6.1",
+  "version": "1.0.7",
   "description": "Requires the right version of Parse JS SDK for a particular platform",
   "main": "parse-shim.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "Tyler Brock",
   "license": "MIT",
   "dependencies": {
+    "detect-node": "^2.0.3",
     "parse": "^1.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Tyler Brock",
   "license": "MIT",
   "dependencies": {
-    "detect-node": "^2.0.3",
+    "detect-is-node": "^1.0.3",
     "parse": "^1.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-shim",
-  "version": "1.0.6",
+  "version": "1.0.6.1",
   "description": "Requires the right version of Parse JS SDK for a particular platform",
   "main": "parse-shim.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/HustleInc/parse-shim"
+    "url": "https://github.com/TouchInnovation/parse-shim.git"
   },
   "keywords": [
     "parse",
@@ -21,6 +21,6 @@
   "author": "Tyler Brock",
   "license": "MIT",
   "dependencies": {
-    "parse": ">= 1.6.0"
+    "parse": "^1.9.2"
   }
 }

--- a/parse-shim.js
+++ b/parse-shim.js
@@ -1,5 +1,7 @@
 // This is a shim that loads the correct version of parse for a given environment
-if (typeof window === 'undefined') {
+if (Parse) {
+  module.exports = Parse;
+} else if (typeof window === 'undefined') {
   module.exports = require('parse/node');
 } else {
   module.exports = require('parse');

--- a/parse-shim.js
+++ b/parse-shim.js
@@ -1,7 +1,10 @@
 // This is a shim that loads the correct version of parse for a given environment
+
+const isNode = require('detect-node')
+
 if ( typeof Parse !== 'undefined' && Parse ) {
   module.exports = Parse;
-} else if (typeof window === 'undefined') {
+} else if (isNode) {
   module.exports = require('parse/node');
 } else {
   module.exports = require('parse');

--- a/parse-shim.js
+++ b/parse-shim.js
@@ -1,6 +1,6 @@
 // This is a shim that loads the correct version of parse for a given environment
 
-const isNode = require('detect-node')
+const isNode = require('detect-is-node')
 
 if ( typeof Parse !== 'undefined' && Parse ) {
   module.exports = Parse;

--- a/parse-shim.js
+++ b/parse-shim.js
@@ -1,5 +1,5 @@
 // This is a shim that loads the correct version of parse for a given environment
-if (Parse) {
+if ( typeof Parse !== 'undefined' && Parse ) {
   module.exports = Parse;
 } else if (typeof window === 'undefined') {
   module.exports = require('parse/node');


### PR DESCRIPTION
1. Detect whether running in node or browser using the ‘detect-is-node’ module, which accounts for the window global being declared through JS DOM.
2. Incorporate changes from TouchInnovation's fork that check for global parse existence.
