### PR TITLE
Teach parse-shim to avoid Parse 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "author": "Tyler Brock",
   "license": "MIT",
   "dependencies": {
-    "parse": ">= 1.6.0"
+    "parse": "^1.6.0"
   }
 }


### PR DESCRIPTION
Parse v2 removes Parse.Promise which breaks stuff. Teach parse-shim to stick to Parse v1.x